### PR TITLE
README.md: update cask install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install the latest version from the [releases tab]( https://github.com/actuallym
 Or via homebrew:
 
 ```shell
-brew cask install wintertime
+brew install --cask wintertime
 ```
 
 ## Usage


### PR DESCRIPTION
Technically it doesn’t need `--cask` if there’s no formula with that name, but it doesn’t hurt to have it there and be more future-proof.